### PR TITLE
Fixed deprecated methods, optimized select methods, and now require UUID instead of Player for Arena object getter

### DIFF
--- a/src/main/java/dev/enderman/minecraft/plugins/games/bedwars/commands/BedwarsCommand.java
+++ b/src/main/java/dev/enderman/minecraft/plugins/games/bedwars/commands/BedwarsCommand.java
@@ -49,7 +49,7 @@ public final class BedwarsCommand extends AbstractCommand {
 					);
 				}
 			} else if ("leave".equalsIgnoreCase(args[0])) {
-				final Arena arena = plugin.getArenaManager().getArena(player);
+				final Arena arena = plugin.getArenaManager().getArenaByPlayerUUID(player.getUniqueId());
 
 				if (arena == null) {
 					player.sendMessage(ChatColor.RED + "You are not in an arena!");
@@ -63,7 +63,7 @@ public final class BedwarsCommand extends AbstractCommand {
 			}
 		} else if (args.length == 2) {
 			if ("join".equalsIgnoreCase(args[0])) {
-				final Arena playerArena = plugin.getArenaManager().getArena(player);
+				final Arena playerArena = plugin.getArenaManager().getArenaByPlayerUUID(player.getUniqueId());
 
 				if (playerArena != null) {
 					player.sendMessage(ChatColor.RED + "You are already in an arena! Use " + ChatColor.UNDERLINE + "/bedwars leave" + ChatColor.RED + " to leave.");

--- a/src/main/java/dev/enderman/minecraft/plugins/games/bedwars/event/listeners/ConnectionListener.java
+++ b/src/main/java/dev/enderman/minecraft/plugins/games/bedwars/event/listeners/ConnectionListener.java
@@ -28,7 +28,7 @@ public final class ConnectionListener implements Listener {
 	public void onPlayerQuit(@NotNull final PlayerQuitEvent event) {
 		final Player player = event.getPlayer();
 
-		final Arena arena = plugin.getArenaManager().getArena(player);
+		final Arena arena = plugin.getArenaManager().getArenaByPlayerUUID(player.getUniqueId());
 
 		if (arena != null) {
 			arena.removePlayer(player);

--- a/src/main/java/dev/enderman/minecraft/plugins/games/bedwars/event/listeners/GameListener.java
+++ b/src/main/java/dev/enderman/minecraft/plugins/games/bedwars/event/listeners/GameListener.java
@@ -50,7 +50,7 @@ public final class GameListener implements Listener {
 			return;
 		}
 
-		final Arena arena = plugin.getArenaManager().getArena(clickedEntity.getUniqueId());
+		final Arena arena = plugin.getArenaManager().getArenaByEntityUUID(clickedEntity.getUniqueId());
 
 		if (arena != null) {
 			Bukkit.dispatchCommand(event.getPlayer(), "bedwars join " + arena.getID());
@@ -62,7 +62,7 @@ public final class GameListener implements Listener {
 	public void onEntityDamageByEntity(@NotNull final EntityDamageByEntityEvent event) {
 
 		if (event.getDamager() instanceof final Player attacker) {
-			final Arena arena = plugin.getArenaManager().getArena(attacker);
+			final Arena arena = plugin.getArenaManager().getArenaByPlayerUUID(attacker.getUniqueId());
 
 			if (arena != null && arena.getState() != GameState.PLAYING) {
 				event.setCancelled(true);
@@ -72,7 +72,7 @@ public final class GameListener implements Listener {
 
 	@EventHandler
 	public void onBlockBreak(@NotNull final BlockBreakEvent event) {
-		final Arena arena = plugin.getArenaManager().getArena(event.getPlayer());
+		final Arena arena = plugin.getArenaManager().getArenaByPlayerUUID(event.getPlayer().getUniqueId());
 
 		if (arena == null) {
 			return;
@@ -98,7 +98,7 @@ public final class GameListener implements Listener {
 	@EventHandler
 	public void onPlayerDeath(@NotNull final PlayerDeathEvent event) {
 		final Player player = event.getEntity();
-		final Arena arena = plugin.getArenaManager().getArena(player);
+		final Arena arena = plugin.getArenaManager().getArenaByPlayerUUID(player.getUniqueId());
 
 		if (arena != null && arena.getState() == GameState.PLAYING) {
 			arena.getGame().handleDeath(player);
@@ -108,7 +108,7 @@ public final class GameListener implements Listener {
 	@EventHandler
 	public void onPlayerRespawn(@NotNull final PlayerRespawnEvent event) {
 		final Player player = event.getPlayer();
-		final Arena arena = plugin.getArenaManager().getArena(player);
+		final Arena arena = plugin.getArenaManager().getArenaByPlayerUUID(player.getUniqueId());
 
 		if (arena == null) {
 			return;
@@ -116,7 +116,7 @@ public final class GameListener implements Listener {
 
 		event.setRespawnLocation(
 						arena.getState() == GameState.PLAYING ?
-										arena.getGame().getRespawnLocation(player)
+										arena.getGame().getRespawnLocation(player.getUniqueId())
 										: arena.getSpawnLocation()
 		);
 	}

--- a/src/main/java/dev/enderman/minecraft/plugins/games/bedwars/managers/ArenaManager.java
+++ b/src/main/java/dev/enderman/minecraft/plugins/games/bedwars/managers/ArenaManager.java
@@ -15,6 +15,7 @@ import dev.enderman.minecraft.plugins.games.bedwars.BedwarsPlugin;
 import dev.enderman.minecraft.plugins.games.bedwars.enums.Team;
 import dev.enderman.minecraft.plugins.games.bedwars.types.Arena;
 import dev.enderman.minecraft.plugins.games.bedwars.utility.types.BedLocation;
+import net.kyori.adventure.text.Component;
 
 import java.util.*;
 
@@ -125,7 +126,7 @@ public final class ArenaManager {
 
 			Objective objective = scoreboard.registerNewObjective("bedwars_scoreboard", Criteria.DUMMY, "dummy");
 			objective.setDisplaySlot(DisplaySlot.SIDEBAR);
-			objective.setDisplayName(ChatColor.YELLOW.toString() + ChatColor.BOLD + "Bedwars"); // Colour codes count as 2 characters. No character limit.
+			objective.displayName(Component.text(ChatColor.YELLOW.toString() + ChatColor.BOLD + "Bedwars")); // Colour codes count as 2 characters. No character limit.
 
 			// Every line has to be unique.
 
@@ -145,8 +146,8 @@ public final class ArenaManager {
 				final org.bukkit.scoreboard.Team teamBedStatus = scoreboard.registerNewTeam(currentTeam.name().toLowerCase() + "_team_bed_status");
 				teamBedStatus.addEntry(currentTeam.getColour().toString());
 
-				teamBedStatus.setPrefix(currentTeam.getColour() + currentTeam.getName() + " "); // 1.13+ -> No character limit.
-				teamBedStatus.setSuffix(ChatColor.GREEN + "✔");
+				teamBedStatus.prefix(Component.text(currentTeam.getColour() + currentTeam.getName() + " ")); // 1.13+ -> No character limit.
+				teamBedStatus.suffix(Component.text(ChatColor.GREEN + "✔"));
 
 				objective.getScore(currentTeam.getColour().toString()).setScore(index);
 			}
@@ -174,9 +175,9 @@ public final class ArenaManager {
 		return scoreboards;
 	}
 
-	public @Nullable Arena getArena(@NotNull final Player player) {
+	public @Nullable Arena getArenaByPlayerUUID(@NotNull final UUID playerUUID) {
 		for (final Arena arena : arenas) {
-			if (arena.getPlayers().contains(player.getUniqueId())) {
+			if (arena.getPlayers().contains(playerUUID)) {
 				return arena;
 			}
 		}
@@ -194,7 +195,7 @@ public final class ArenaManager {
 		return null;
 	}
 
-	public @Nullable Arena getArena(@NotNull final UUID entityUUID) {
+	public @Nullable Arena getArenaByEntityUUID(@NotNull final UUID entityUUID) {
 		for (final Arena arena : arenas) {
 			if (arena.getVillager().getUniqueId().equals(entityUUID)) {
 				return arena;

--- a/src/main/java/dev/enderman/minecraft/plugins/games/bedwars/managers/NameTagManager.java
+++ b/src/main/java/dev/enderman/minecraft/plugins/games/bedwars/managers/NameTagManager.java
@@ -5,13 +5,14 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 import dev.enderman.minecraft.plugins.games.bedwars.enums.Team;
+import net.kyori.adventure.text.Component;
 
 public final class NameTagManager {
 	public static void setNameTags(@NotNull final Player player) {
 		for (final Team team : Team.values()) {
 			if (player.getScoreboard().getTeam(team.name() + "_team") == null) {
 				final org.bukkit.scoreboard.Team boardTeam = player.getScoreboard().registerNewTeam(team.name() + "_team");
-				boardTeam.setPrefix(team.getColour() + team.getName() + " ");
+				boardTeam.prefix(Component.text(team.getColour() + team.getName() + " "));
 			}
 		}
 	}
@@ -22,7 +23,7 @@ public final class NameTagManager {
 
 			if (teamTeam == null) {
 				teamTeam = target.getScoreboard().registerNewTeam(team.name() + "_team");
-				teamTeam.setPrefix(team.getColour() + team.getName() + " ");
+				teamTeam.prefix(Component.text(team.getColour() + team.getName() + " "));
 			}
 
 			teamTeam.addEntry(player.getName());

--- a/src/main/java/dev/enderman/minecraft/plugins/games/bedwars/types/Arena.java
+++ b/src/main/java/dev/enderman/minecraft/plugins/games/bedwars/types/Arena.java
@@ -70,14 +70,14 @@ public final class Arena {
 
 
 		if (kickPlayers) {
-			for (final UUID uuid : players) {
-				final Player player = Bukkit.getPlayer(uuid);
+			for (final UUID playerUUID : players) {
+				final Player player = Bukkit.getPlayer(playerUUID);
 				assert player != null;
 
 				player.teleport(ConfigurationUtility.getLobbySpawn());
 				player.getInventory().clear();
 
-				final BossBar playerBossBar = plugin.getArenaManager().getBossBars().get(game.getTeams().get(player.getUniqueId()));
+				final BossBar playerBossBar = plugin.getArenaManager().getBossBars().get(game.getTeams().get(playerUUID));
 				player.setScoreboard(Objects.requireNonNull(Bukkit.getScoreboardManager()).getNewScoreboard());
 
 				if (playerBossBar != null) {

--- a/src/main/java/dev/enderman/minecraft/plugins/games/bedwars/types/Game.java
+++ b/src/main/java/dev/enderman/minecraft/plugins/games/bedwars/types/Game.java
@@ -169,14 +169,14 @@ public final class Game {
 		}
 	}
 
-	public Location getRespawnLocation(@NotNull final Player player) {
-		final Team team = teams.get(player.getUniqueId());
+	public Location getRespawnLocation(@NotNull final UUID playerUUID) {
+		final Team team = teams.get(playerUUID);
 
 		if (bedsAlive.get(team)) {
 			return arena.getSpawns().get(team);
-		} else {
-			return ConfigurationUtility.getLobbySpawn();
 		}
+
+		return ConfigurationUtility.getLobbySpawn();
 	}
 
 	public void cancelTasks() {


### PR DESCRIPTION
Renamed getArena to getArenaByPlayerUUID to ensure that player.getUniqueID() is evaluated at the time of method invocation, rather than returning null after the method is called.